### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Go Build and Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/traP-jp/h25s_20/security/code-scanning/1](https://github.com/traP-jp/h25s_20/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Based on the provided workflow, it appears that the workflow only needs to read the repository contents and does not require any write permissions. Therefore, we will set `contents: read` in the `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
